### PR TITLE
Made everything automatic

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,21 +17,24 @@
  ## How To Use
 Start by forking or downloading this repository. There is mainly 2 file from this repository that you need, <a href="js/script.js">script.js</a> and <a href="css/styles.css">styles.css</a>. The JavaScript file gets necessary information about the users repositories from GitHub's api and the css file contains styling for elements.
 
-Find the script.js file located at `js/script.js`, place the file in your project and uncomment and edit the following lines:
-
-```javascript
-var user = ""; //put GitHub username in the ""
-window.onload = genRepo(user);
-```
-<i>Note: another method would be to call the </i>`genRepo("username")`<i> function with a button or a form which wouldn't require you to do this step.</i>
-
-
- Go to your projects's html page and make sure you reference the JavaScript file in the head if you havn't done so, eg:
+Go to your projects's html page and make sure you reference the JavaScript file in the head if you havn't done so, eg:
  ```html
 <script src="js/script.js"></script>
  ``` 
 
- In the html page and add a div named `repo-box` where you want the repositiories to show:
+### If you want a form instead of auto list
+Find the script.js file located at `js/script.js`, place the file in your project and comment and edit the following lines:
+
+```javascript
+var user = ...;
+window.onload = genRepo(user);
+```
+<i>BTW: another method would be to call the </i>`genRepo("username")`<i> function with a button or a form which wouldn't require you to do this step.</i>
+
+In the html page remove the comment out besides the div with ID of `title` to return the form.
+
+### Extras
+In the html page you can move the div named `repo-box` where you want the repositiories to show:
 ```html
 <div id="repo-box"></div>
 ```

--- a/index.html
+++ b/index.html
@@ -25,13 +25,14 @@
 
 <body>
     
-
+<!--
     <div id="title">
         <h1>Enter GitHub Username:</h1>
         <input id="user" type="text" placeholder="seyon123">
         <button id="btn" onclick="getusername()">View Repos</button>
         <br><i>*Repos may appear at a slower rate compared to other content on screen.</i>
     </div>
+-->
 
     <div id="back">
         <a href="index.html">Go Back</a>

--- a/js/script.js
+++ b/js/script.js
@@ -7,7 +7,7 @@
 // To use this file uncomment the  following 2 lines of code and 
 // enter GitHub username in the ""
 
-var user = "";
+var user = document.domain.split('.', 1);
 window.onload = genRepo(user);
 
 

--- a/js/script.js
+++ b/js/script.js
@@ -7,8 +7,8 @@
 // To use this file uncomment the  following 2 lines of code and 
 // enter GitHub username in the ""
 
-// var user = "";
-// window.onload = genRepo(user);
+var user = "";
+window.onload = genRepo(user);
 
 
 function genRepo(user) {


### PR DESCRIPTION
Since GitHub doesn't allow dots in usernames, there's no need to specify the username manually. All that's needed is to grab the domain, split it to dots and take the first part.

Then the form can become the optional part.